### PR TITLE
DTree(VariableOrder) from SQL

### DIFF
--- a/frontend/src/main/scala/fdbresearch/Driver.scala
+++ b/frontend/src/main/scala/fdbresearch/Driver.scala
@@ -9,21 +9,21 @@
 //===----------------------------------------------------------------------===//
 package fdbresearch
 
-import fdbresearch.tree.{DTreeNode, DTreeRelation, Tree, ViewTree}
+import fdbresearch.tree.{VariableOrderNode, VariableOrderRelation, Tree, ViewTree}
 import fdbresearch.core.{SQL, SQLToM3Compiler, Source}
 import fdbresearch.parsing.M3Parser
 import fdbresearch.util.Logger
 
 class Driver {
 
-  import fdbresearch.tree.DTree._
+  import fdbresearch.tree.VariableOrder._
 
   // TODO: allow definitions of unused streams and tables
 
   /**
     * Check if all SQL sources have consistent schemas with DTree relations
     */
-  private def checkSchemas(sqlSources: List[Source], relations: List[DTreeRelation]): Unit = {
+  private def checkSchemas(sqlSources: List[Source], relations: List[VariableOrderRelation]): Unit = {
     val rm = relations.map { r =>
       r.name -> r.keys.map(v => (v.name, v.tp)).toSet
     }.toMap
@@ -47,7 +47,7 @@ class Driver {
     }.asInstanceOf[SQL.System]
   }
 
-  def compile(sql: SQL.System, dtree: Tree[DTreeNode], batchUpdates: Boolean): String = {
+  def compile(sql: SQL.System, dtree: Tree[VariableOrderNode], batchUpdates: Boolean): String = {
 
     checkSchemas(sql.sources, dtree.getRelations)
 

--- a/frontend/src/main/scala/fdbresearch/Main.scala
+++ b/frontend/src/main/scala/fdbresearch/Main.scala
@@ -10,9 +10,10 @@
 package fdbresearch
 
 import fdbresearch.parsing.{DTreeParser, SQLParser}
-import fdbresearch.util.Logger
-import java.io.File
 import fdbresearch.tree.DTree
+import fdbresearch.util.Logger
+
+import java.io.File
 
 object Main extends App {
 
@@ -60,14 +61,13 @@ object Main extends App {
       val sql = parseSQL(sqlFile)
       Logger.instance.debug("SQL AST: " + sql.toString)
 
-      val dtreeFile = new File(sqlFile.getParentFile.getAbsolutePath, sql.dtree.file.path)
-      val dtree = parseDTree(dtreeFile)
+      //val dtreeFile = new File(sqlFile.getParentFile.getAbsolutePath, sql.dtree.file.path)
+      //val dtree = parseDTree(dtreeFile)
 
-      // Here we need to create the dtree using the sql object instead of the dtreeFile
-      val newDTree = DTree.apply(sql)
-      Logger.instance.debug("DTREE AST: " + dtree.toString)
+      val dTree = DTree.apply(sql)
+      Logger.instance.debug("DTREE AST: " + dTree.toString)
 
-      val output = new Driver().compile(sql, newDTree, config.batchUpdates)
+      val output = new Driver().compile(sql, dTree, config.batchUpdates)
       config.outputM3 match {
         case Some(file) => new java.io.PrintWriter(file) {
           write(output); close()

--- a/frontend/src/main/scala/fdbresearch/Main.scala
+++ b/frontend/src/main/scala/fdbresearch/Main.scala
@@ -12,6 +12,7 @@ package fdbresearch
 import fdbresearch.parsing.{DTreeParser, SQLParser}
 import fdbresearch.util.Logger
 import java.io.File
+import fdbresearch.tree.DTree
 
 object Main extends App {
 
@@ -61,9 +62,12 @@ object Main extends App {
 
       val dtreeFile = new File(sqlFile.getParentFile.getAbsolutePath, sql.dtree.file.path)
       val dtree = parseDTree(dtreeFile)
+
+      // Here we need to create the dtree using the sql object instead of the dtreeFile
+      val newDTree = DTree.apply(sql)
       Logger.instance.debug("DTREE AST: " + dtree.toString)
 
-      val output = new Driver().compile(sql, dtree, config.batchUpdates)
+      val output = new Driver().compile(sql, newDTree, config.batchUpdates)
       config.outputM3 match {
         case Some(file) => new java.io.PrintWriter(file) {
           write(output); close()

--- a/frontend/src/main/scala/fdbresearch/core/AST.scala
+++ b/frontend/src/main/scala/fdbresearch/core/AST.scala
@@ -103,8 +103,8 @@ case class TypeDefinition(name: String, file: SourceFile,
          |WITH PARAMETER SCHEMA (${schema.mkString(", ")});""".stripMargin
 }
 
-case class DTreeDefinition(file: SourceFile) extends Tree {
-  override def toString = s"""IMPORT DTREE FROM $file;"""
+case class VariableOrderDefinition(file: SourceFile) extends Tree {
+  override def toString = s"""IMPORT VARIABLEORDER FROM $file;"""
 }
 
 // -----------------------------------------------------------------------------
@@ -658,13 +658,13 @@ object SQL {
 
 
   // ---------- System
-  case class System(dtree: DTreeDefinition,
+  case class System(variableOrder: Option[VariableOrderDefinition],
                     typeDefs: List[TypeDefinition],
                     sources: List[Source],
                     queries: List[Query]) extends SQL {
     override def toString =
       "---------------- DTREE IMPORT ---------------\n" +
-        dtree.toString + "\n\n" +
+        variableOrder.toString + "\n\n" +
         "---------------- TYPE DEFINITIONS ---------------\n" +
         typeDefs.mkString("\n\n") + "\n\n" +
         "-------------------- SOURCES --------------------\n" +

--- a/frontend/src/main/scala/fdbresearch/parsing/Parser.scala
+++ b/frontend/src/main/scala/fdbresearch/parsing/Parser.scala
@@ -157,6 +157,7 @@ class Parser extends StandardTokenParsers {
     | "PARTITIONED" ~> "RANDOMLY" ^^^ DistRandomExp
     )
 
-  lazy val dtree: Parser[DTreeDefinition] =
-    "IMPORT" ~> "DTREE" ~> "FROM" ~> sourceIn <~ ";" ^^ { f => DTreeDefinition(f) }
+  // TODO Maybe change DTREE to VARIABLEORDER (will need to update all example files)
+  lazy val variableOrder: Parser[VariableOrderDefinition] =
+    "IMPORT" ~> "DTREE" ~> "FROM" ~> sourceIn <~ ";" ^^ { f => VariableOrderDefinition(f) }
 }

--- a/frontend/src/main/scala/fdbresearch/parsing/SQLParser.scala
+++ b/frontend/src/main/scala/fdbresearch/parsing/SQLParser.scala
@@ -231,8 +231,8 @@ class SQLParser extends Parser with (String => SQL.System) {
 
   // ------------ System definition
   lazy val system: Parser[System] =
-    dtree ~ rep(typeDef) ~ rep(source) ~ rep(select <~ opt(";")) ^^ {
-      case dt ~ td ~ ss ~ qs => System(dt, td, ss, qs)
+    opt(variableOrder) ~ rep(typeDef) ~ rep(source) ~ rep(select <~ opt(";")) ^^ {
+      case vo ~ td ~ ss ~ qs => System(vo, td, ss, qs)
     }
 
   def apply(str: String): System = phrase(system)(new lexical.Scanner(str)) match {

--- a/frontend/src/main/scala/fdbresearch/tree/DTree.scala
+++ b/frontend/src/main/scala/fdbresearch/tree/DTree.scala
@@ -10,6 +10,7 @@
 package fdbresearch.tree
 
 import fdbresearch.core._
+import scala.annotation.tailrec
 
 /**
   * DTree nodes and operations
@@ -23,7 +24,7 @@ trait DTreeNode {
   override def toString: String =
     name + "[" + keys.map(_.name).mkString(", ") + "]"
 }
-case class DTreeVariable(name: String, tp: Type, keys: List[DTreeVariable]) extends DTreeNode
+case class DTreeVariable(name: String, tp: Type, var keys: List[DTreeVariable]) extends DTreeNode
 
 case class DTreeRelation(name: String, keys: List[DTreeVariable]) extends DTreeNode {
   val tp: Type = TypeLong
@@ -44,5 +45,99 @@ object DTree {
         p.variablePreorderIndex +
           tree.leftSiblings.map(_.getVariables.size).sum + 1
       ).getOrElse(0)
+  }
+
+  // Below is where we're going to implement creating a Tree[DTreeNode] direct from sql
+  // Basic idea:
+  // 1. Using SQL object extract info and create DTreeNodes
+  // 2. Assemble them into a tree of LinkedNodes, and then flatten these into a List[LinkedNode] like in DTreeParser
+  // 3. Build a Tree[DTreeNode] from the aforementioned list
+  private class LinkedNode(val node: DTreeNode, val children: Option[List[LinkedNode]], val relations: Set[String])
+  private val variableMap = collection.mutable.Map[String, (DTreeVariable, Set[String])]()
+  def apply(sql: SQL.System): Tree[DTreeNode] = {
+    // 1. Go through each source and the fields to the Map as Key=fieldName, value=(variableNode, relationsSet)
+    def addSchemaToMap(schema: Schema): Unit = {
+      schema.fields.foreach(addFieldToMap)
+      def addFieldToMap(field: (String, Type)): Unit = {
+        val (variableNode, relations) = variableMap.getOrElse(field._1, (DTreeVariable(field._1, field._2, List.empty), Set(schema.name)))
+        variableMap.update(field._1, (variableNode, relations + schema.name))
+      }
+    }
+    sql.sources.foreach { src => addSchemaToMap(src.schema)}
+
+    // 2. Create a list of DTreeRelation nodes wrapped in LinkedNodes for each relation
+    // This will be the list of subtrees which will be combined into 1 tree of linked LinkedNodes
+    val subtrees = sql.sources.map({
+      src => {
+        val keys: List[DTreeVariable] = src.schema.fields.map(
+          field => {
+            variableMap(field._1) match {
+              case (variable, _) => variable
+            }
+          }
+        )
+        val relation = DTreeRelation(src.schema.name, keys)
+        new LinkedNode(relation, None, Set(src.schema.name))
+      }
+    })
+
+    // 3. Create a sorted list of all the key-value pairs in the Map
+    val sortedVariableList = variableMap.toList
+      .sortBy { case (_, (_, set)) => set.size }
+      .map { case (_, value) => value }
+
+    // 4. For each field in the sortedVariableList, create a LinkedNode that joins the
+    // appropriate subtrees. This will ultimately result in one root
+    @tailrec
+    def createLinkedNodes(fields: List[(DTreeVariable, Set[String])], subtrees:List[LinkedNode]):List[LinkedNode] = {
+      fields match {
+        case (variable, relations) :: tail =>
+          // 1. Find subtrees that contain those relations and those that don't
+          val (subtreesToMerge, subtreesToKeep) = subtrees.partition(linkedNode => linkedNode.relations.intersect(relations).nonEmpty)
+          // 2. Make a new LinkNode to link those subtrees at this variable
+          val newLinkedNode = new LinkedNode(variable, Option(subtreesToMerge), relations)
+          // 3. Subtrees should now be:
+          val updatedSubTrees = subtreesToKeep :+ newLinkedNode
+          // 4. Call the method again
+          createLinkedNodes(tail, updatedSubTrees)
+        case Nil => subtrees
+      }
+    }
+    // TODO: Maybe assert here that creatLinkedNodes ultimately only return a list of length one
+    val root:LinkedNode = createLinkedNodes(sortedVariableList, subtrees).head
+
+    // 5. Now we have a tree of linked nodes we can obtain the keys for the variables
+    def populateKeys(currentNode: LinkedNode): Set[DTreeVariable] = {
+      currentNode.node match {
+        case variable: DTreeVariable =>
+          val childrenKeys: Set[DTreeVariable] = currentNode.children match {
+            case Some(children) => children.flatMap(child => populateKeys(child)).toSet
+            case None => Set.empty
+          }
+          val currentKeys = childrenKeys - variable
+          variable.keys = currentKeys.toList
+          currentKeys
+        case relation: DTreeRelation => relation.keys.toSet
+      }
+    }
+    populateKeys(root)
+
+    // 6. Flatten the 'tree' of linked nodes into a list
+    def createLinkedNodeList(currentNode: LinkedNode): List[LinkedNode] = {
+      currentNode.children match {
+        case Some(list) => list.flatMap(createLinkedNodeList) :+ currentNode
+        case None => List(currentNode)
+      }
+    }
+    val linkedNodeList = createLinkedNodeList(root)
+
+    // 7. Build the actual tree from the list of linked nodes
+    def createChildTrees(parent: Tree[DTreeNode]): List[Tree[DTreeNode]] = {
+      linkedNodeList.filter(_.node.equals(parent.node)).head.children match {
+        case Some(list) => list.map(n => new Tree(n.node, Some(parent), createChildTrees))
+        case None => List.empty
+      }
+    }
+    new Tree(root.node, None, createChildTrees)
   }
 }

--- a/frontend/src/main/scala/fdbresearch/tree/Tree.scala
+++ b/frontend/src/main/scala/fdbresearch/tree/Tree.scala
@@ -19,6 +19,8 @@ class Tree[A](val node: A, private var _parent: Option[Tree[A]],
 
   def parent: Option[Tree[A]] = _parent
 
+  def setParent(p: Tree[A]) = _parent = Some(p)
+
   val children: List[Tree[A]] = childrenFactory(this)
 
   def isRoot: Boolean = parent.isEmpty


### PR DESCRIPTION
The main contribution of this pull request is the ability to automatically create a VariableOrder (formerly a DTree) directly from the SQL. This is particularly useful for queries that have data sources that are relations with many tens of variables meaning creating a dtree by hand is not practical. The logic behind this algorithm is detailed below. In implementing this change, we have made it so a DTree/VariableOrder can still be supplied via .txt file if declared in the .sql file. If no file is supplied, our algorithm will automatically produce the DTree/VariableOrder.

Additional improvements:
- Removed some 'source not closed' in main.scala.
- Renamed DTree to VariableOrder in all places except the in the SQL parser for parsing the DTree import statement. NOTE: There is a ToDo here to rename this too, but this requires also updating the queries in the examples directory.
- Removed keys from DTreeVariable (now known as VariableOrderVar) as these only exist in the context of the complete VariableOrder.
- Added getKeys to VariableOrderImp (formerly DTreeImp) to calculate and return the keys for a given node in the VariableOrder.

DTree/VariableOrder Logic:
1. Build the VariableOrder starting at the leaves: Create a list of subtrees, where each subtree is a Tree of a relation node, one for each relation.
2. Order of all the variables from the query in a list in order of least to most number of relations they are a part of (maintaining the order they appear in a relation if there are ties).
3. For each variable in the list, take the variable and make it the parent of any subtrees that contain relations that this variable appears in. Any subtrees that are merged in this step are removed, and the replaced with the subtree rooted at this new parent.
4. By considering all variables in the list, we will end up with one remaining subtree that is our VariableOrder.